### PR TITLE
Allow leaflet pipes on addrasterrgb and addstarsimage

### DIFF
--- a/R/addRasterRGB.R
+++ b/R/addRasterRGB.R
@@ -65,6 +65,16 @@ addRasterRGB <- function(
   ...
 ) {
 
+  # this allows using `addRasterRGB` directly on a leaflet pipe, without
+  # specifying `data` (e.g., leaflet(plainview::poppendorf) %>%
+  #  addProviderTiles("OpenStreetMap") %>% addRasterRGB())
+  #
+  if (inherits(map, c("leaflet", "leaflet_proxy"))) {
+    if (missing(x)) {
+      x <- attributes(map[["x"]])[["leafletData"]]
+    }
+  }
+
   if (inherits(x, "Raster")) {
 
     mat <- cbind(x[[r]][],

--- a/R/addStarsImage.R
+++ b/R/addStarsImage.R
@@ -46,7 +46,7 @@
 #' @importFrom sf st_as_sfc st_bbox st_transform
 #' @importFrom base64enc base64encode
 #' @importFrom png writePNG
-#' @export addStarsImage
+#' @export
 addStarsImage <- function(
   map,
   x,
@@ -61,6 +61,17 @@ addStarsImage <- function(
   maxBytes = 4 * 1024 * 1024,
   data = getMapData(map)
 ) {
+
+  # this allows using `addStarsImage` directly on a leaflet pipe, without
+  # specifying `x` (e.g., leaflet(read_stars(tif)) %>%
+  # addProviderTiles("OpenStreetMap") %>% addStarsImage())
+  #
+  if (inherits(map, c("leaflet", "leaflet_proxy"))) {
+    if (missing(x)) {
+      x <- attributes(map[["x"]])[["leafletData"]]
+    }
+  }
+
   stopifnot(inherits(x, "stars"))
 
   raster_is_factor <- raster::is.factor(x)


### PR DESCRIPTION
For "coherence" with other functions (e.g., addFeatures, addStaticLabels...), this PR would allow using addRasterRGB and addStarsImage in leaflet pipes, without specifying the "data" argument, such as in: 

``` r
indata = plainview::poppendorf
leaflet(indata) %>%
  addProviderTiles("OpenStreetMap") %>% 
  addRasterRGB(r = 5, g = 4, b = 3)
```

or:

``` r 
tif = read_stars(system.file("tif/L7_ETMs.tif", package = "stars"))
leaflet(tif) %>%
  addProviderTiles("OpenStreetMap") %>% 
  addStarsImage(band = 4)
```