### PR TITLE
fix addImageQuery for leafletProxy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,11 @@ Authors@R:
              role = c("ctb")),
       person(given = "Miles",
              family = "McBain",
-             role = c("ctb")))           
+             role = c("ctb")),
+      person(given = "Sebastian",
+             family = "Gatscha",
+             role = "ctb",
+             email = "sebastian_gatscha@gmx.at"))           
 Maintainer: Tim Appelhans <tim.appelhans@gmail.com>
 Description: Provides extensions for packages 'leaflet' & 'mapdeck', 
     many of which are used by package 'mapview'. 

--- a/R/imagequery.R
+++ b/R/imagequery.R
@@ -121,24 +121,13 @@ addImageQuery = function(map,
                          name = "joda",
                          src = system.file("htmlwidgets/lib/joda",
                                            package = "leafem"),
-                         script = "joda.js")
+                         script = c("joda.js",
+                                    "addImageQuery-bindings.js"))
                        ))
 
-  map = htmlwidgets::onRender(
-    map,
-    htmlwidgets::JS(
-      paste0(
-        'function(el, x, data) {
-        var map = this;
-        map.on("', type, '", function (e) {
-          rasterPicker.pick(e, x, ', digits, ', "', prefix, ' ");
-        });
-      }'
-      )
-    )
-  )
+  bounds <- as.numeric(sf::st_bbox(projected))
 
-  return(map)
+  leaflet::invokeMethod(map, NULL, "addImageQuery", layerId, bounds, type, digits, prefix)
 }
 
 ##############################################################################

--- a/inst/htmlwidgets/lib/joda/addImageQuery-bindings.js
+++ b/inst/htmlwidgets/lib/joda/addImageQuery-bindings.js
@@ -1,0 +1,17 @@
+/* global LeafletWidget, $, L */
+LeafletWidget.methods.addImageQuery = function(layerId, bounds, type, digits, prefix) {
+  (function(){
+    var map = this;
+
+    // Create correct bounding box.
+    var boundsarr = [
+      [bounds[3],bounds[0]],
+      [bounds[1],bounds[2]]
+      ];
+
+    map.on(type, function(e) {
+        rasterPicker.pick(e, layerId, boundsarr, digits, prefix);
+    });
+  }).call(this);
+};
+


### PR DESCRIPTION
This should close #7 

I had to rewrite/simplify some parts of `joda.js`. Is this from a library or is it custom made for `addImageQuery`?

It also fixes a small issue in `rasterPicker.renderInfo` when `layer.value` is `null`.

I just tested it with the examples from #7, so maybe some more testing is needed.


Looking at the code of `imagequery.R`, Rstudio told me that `starspathDatFn` and `datFn` are defined but not used.