### PR TITLE
Hide addImageQuery legend if empty/not visible

### DIFF
--- a/R/imagequery.R
+++ b/R/imagequery.R
@@ -25,6 +25,7 @@
 #' @param digits the number of digits to be shown in the display field.
 #' @param position where to place the display field. Default is 'topright'.
 #' @param prefix a character string to be shown as prefix for the layerId.
+#' @param className a character string to append to the control legend.
 #' @param ... currently not used.
 #'
 #' @return
@@ -62,6 +63,7 @@ addImageQuery = function(map,
                          digits,
                          position = 'topright',
                          prefix = 'Layer',
+                         className = "",
                          ...) {
 
   if (inherits(map, "mapview")) map = mapview2leaflet(map)
@@ -108,7 +110,8 @@ addImageQuery = function(map,
       map,
       html = "",
       layerId = ctrl_nm,
-      position = position
+      position = position,
+      className = paste("info legend", className)
     )
   }
 

--- a/inst/htmlwidgets/lib/joda/joda.js
+++ b/inst/htmlwidgets/lib/joda/joda.js
@@ -28,11 +28,10 @@ rasterPicker.old = function(e, x, data) {
     }
 };
 
-var eventLatLng = {};
 rasterPicker.pick = function(event, layerId, bounds, digits, prefix, visible) {
+  var outputWidget = this.getInfoLegend(layerId);
   if (!visible) {
-    var outputWidget = this.getInfoLegend(layerId);
-    outputWidget.innerHTML = "";
+    $(outputWidget).hide();
     return;
   }
 
@@ -41,38 +40,16 @@ rasterPicker.pick = function(event, layerId, bounds, digits, prefix, visible) {
   // collect values of clicked raster layers
   var rasterHitInfos = this.getLayerIdHits(rasterLayers, event.latlng);
   // Return if nothing was found.
-  if (rasterHitInfos.length === 0) return;
-  // If no event is triggered yet, add e.latlng to Object
-  var rendernew = true;
-  if (Object.keys(eventLatLng).length === 0) {
-    Object.assign(eventLatLng, event.latlng);
-  } else {
-    // If Raster was already queried, check if e.latlng has changed?
-    if (eventLatLng.lat === event.latlng.lat && eventLatLng.lng === event.latlng.lng) {
-      // Still same latlng-event
-      rendernew = false;
-    }  else {
-      // New latlng-event and update Object
-      Object.assign(eventLatLng, event.latlng);
-      rendernew = true;
-    }
+  if (rasterHitInfos.length === 0) {
+    $(outputWidget).hide();
+    return;
   }
-
   for (var rasterHitInfo_key in rasterHitInfos) {
     var rasterHitInfo = rasterHitInfos[rasterHitInfo_key];
     pickedLayerData[rasterHitInfo.layerId] = this.getLayerData(rasterHitInfo, event.latlng /*, event.zoom?*/);
   }
   // render collected hit values
-
-  var outputWidget = this.getInfoLegend(layerId);
   outputWidget.innerHTML = this.renderInfo(pickedLayerData, digits, prefix);
-
-  // Add values to innherHTML. Either refresh the value or append a value.
-  /*if (rendernew) {
-
-  } else {
-    outputWidget.innerHTML = outputWidget.innerHTML + "<br>" + this.renderInfo(pickedLayerData, digits, prefix);
-  }*/
 };
 
 rasterPicker.getInfoLegend = function(layerId) {
@@ -84,17 +61,11 @@ rasterPicker.getInfoLegend = function(layerId) {
   return element;
 };
 
-rasterPicker.getRasterLayers = function(layerIds, bounds) {
-  var rasterLayers = [];
-  // If layerIds is no Array, make it an Array to use `forEach`
-  if (!(layerIds instanceof Array)) {layerIds = [layerIds];}
-  // Loop through every layerId and push to rasterLayers
-  layerIds.forEach(function(layerId) {
-      rasterLayers.push({
+rasterPicker.getRasterLayers = function(layerId, bounds) {
+  var rasterLayers = [{
         layerId: layerId,
         bounds: bounds
-      });
-  });
+      }];
   // TODO check if layer is hidden?
   return rasterLayers;
 };
@@ -151,16 +122,14 @@ rasterPicker.renderInfo = function(pickedLayerData, digits, prefix) {
     var layer = pickedLayerData[layer_key];
     if (layer.value === undefined || layer.value === null) {
       continue;
+    } else {
+      $(document.getElementById("imageValues" + "-" + layer_key)).show();
     }
     if(digits === "null" || digits === null) {
       text += "<small>"+ prefix+ " <strong>"+ layer.layerId + ": </strong>"+ layer.value+ "</small>";
     } else {
       text += "<small>"+ prefix+ " <strong>"+ layer.layerId + ": </strong>"+ layer.value.toFixed(digits)+ "</small>";
     }
-    /*text += "<br/> (lat,lng=" + layer.lat + "," + layer.lng + ")";
-    text += "<br/> (x,y=" + layer.index.x + "," + layer.index.y + ")";
-    text += "</li>\n";*/
   }
-  /*return "<ul>"+text+"</ul>";*/
   return text;
 };

--- a/man/addImageQuery.Rd
+++ b/man/addImageQuery.Rd
@@ -15,6 +15,7 @@ addImageQuery(
   digits,
   position = "topright",
   prefix = "Layer",
+  className = "",
   ...
 )
 }
@@ -43,6 +44,8 @@ to 'mousemove'.}
 \item{position}{where to place the display field. Default is 'topright'.}
 
 \item{prefix}{a character string to be shown as prefix for the layerId.}
+
+\item{className}{a character string to append to the control legend.}
 
 \item{...}{currently not used.}
 }


### PR DESCRIPTION
When the map initializes, the legend control will be visible, but as soon as you hover over the map, they should disappear when no values are found or when the layer is hidden.

I also added the `className` argument to `addImageQuery`, so one can add his own CSS-class to the legend controls.

I also cleaned up joda.js a bit. There were still some leftovers from my previous attempt to display multiple values.

Here's a little example, using the `className`. 

```
library(leaflet)
library(leafem)
library(plainview)
library(shiny)  

style <- HTML(".myownlegendcss {
    margin: 0 !important;
    border-radius: 0;
    border: 0;
    box-shadow: 0 0 0;
}")

ui <- fluidPage(
  tags$head(tags$style(style)),
  leafletOutput("map")
)

server <- function(input, output, session) {
  output$map <- renderLeaflet({
    leaflet() %>%
      addProviderTiles("OpenStreetMap") %>%
      addRasterImage(poppendorf[[1]], project = TRUE, group = "poppendorf1",
                     layerId = "poppendorf1") %>%
      addImageQuery(poppendorf[[1]], project = TRUE,
                    layerId = "poppendorf1", className = "myownlegendcss") %>%
      addRasterImage(poppendorf[[4]], project = TRUE, group = "poppendorf2",
                     layerId = "poppendorf2") %>%
      addImageQuery(poppendorf[[4]], project = TRUE,
                    layerId = "poppendorf2", className = "myownlegendcss") %>%
      addLayersControl(overlayGroups = c("poppendorf1", "poppendorf2"))
  })
}
shinyApp(ui, server)
```
