### PR TITLE
use safer math.js compile/evaluate to eval user arith expressions

### DIFF
--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -83,7 +83,7 @@ function evalMath(a, values) {
  
 const compiledExpressions = {}
 function evalMath(rawExpression, values) {
-  console.log('raw expression', rawExpression)
+  console.log(`raw expression, ${JSON.stringify(rawExpression)}`)
   console.log('raw expression is not in compiledexpressions', !rawExpression in compiledExpressions)
   if (!rawExpression in compiledExpressions) {
     console.log('storing raw expression in compiled')

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -84,8 +84,8 @@ function evalMath(a, values) {
 const compiledExpressions = {}
 function evalMath(rawExpression, values) {
   console.log('raw expression', rawExpression)
-  console.log('raw expression is in compiled expressions', rawExpression in compiledExpressions)
-  if (! rawExpression in compiledExpressions) {
+  console.log('raw expression is not in compiled expressions', !rawExpression in compiledExpressions)
+  if (!rawExpression in compiledExpressions) {
     console.log('storing raw expression in compiled')
     compiledExpressions[rawExpression] = safeCompile(rawExpression).evaluate;
   }

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -84,7 +84,7 @@ function evalMath(a, values) {
 const compiledExpressions = {}
 function evalMath(rawExpression, values) {
   console.log('raw expression', rawExpression)
-  console.log('raw expression is not in compiled expressions', !rawExpression in compiledExpressions)
+  console.log('raw expression is not in compiledexpressions', !rawExpression in compiledExpressions)
   if (!rawExpression in compiledExpressions) {
     console.log('storing raw expression in compiled')
     compiledExpressions[rawExpression] = safeCompile(rawExpression).evaluate;

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -84,6 +84,7 @@ function evalMath(a, values) {
 const compiledExpressions = {}
 function evalMath(rawExpression, values) {
   console.log('raw expression', rawExpression)
+  console.log('raw expression is in compiled expressions', rawExpression in compiledExpressions)
   if (! rawExpression in compiledExpressions) {
     console.log('storing raw expression in compiled')
     compiledExpressions[rawExpression] = safeCompile(rawExpression).evaluate;

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -83,13 +83,9 @@ function evalMath(a, values) {
  
 const compiledExpressions = {}
 function evalMath(rawExpression, values) {
-  console.log(`raw expression, ${JSON.stringify(rawExpression)}`)
-  console.log('raw expression is not in compiledexpressions', !rawExpression in compiledExpressions)
-  if (!rawExpression in compiledExpressions) {
-    console.log('storing raw expression in compiled')
+  if (!(rawExpression in compiledExpressions)) {
     compiledExpressions[rawExpression] = safeCompile(rawExpression).evaluate;
   }
-  console.log('cached expression', compiledExpressions[rawExpression])
   return compiledExpressions[rawExpression]({values});
 }
 

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -83,9 +83,12 @@ function evalMath(a, values) {
  
 const compiledExpressions = {}
 function evalMath(rawExpression, values) {
+  console.log('raw expression', rawExpression)
   if (! rawExpression in compiledExpressions) {
+    console.log('storing raw expression in compiled')
     compiledExpressions[rawExpression] = safeCompile(rawExpression).evaluate;
   }
+  console.log('cached expression', compiledExpressions[rawExpression])
   return compiledExpressions[rawExpression]({values});
 }
 

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/georasterUtils.js
@@ -81,9 +81,15 @@ function evalMath(a, values) {
     return Function('values', 'with(Math) return ' + a)(values);
 } */
  
+const compiledExpressions = {}
 function evalMath(rawExpression, values) {
-    return safeEval(rawExpression, {values});
+  if (! rawExpression in compiledExpressions) {
+    compiledExpressions[rawExpression] = safeCompile(rawExpression).evaluate;
+  }
+  return compiledExpressions[rawExpression]({values});
 }
+
+
 
 
 // helpers from https://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb

--- a/inst/htmlwidgets/lib/georaster-for-leaflet/mathjs.min.js
+++ b/inst/htmlwidgets/lib/georaster-for-leaflet/mathjs.min.js
@@ -47,6 +47,7 @@
    */
   
   const safeEval = math.evaluate;
+  const safeCompile = math.compile;
    
   math.import({
      'import': function () { throw new Error('Function import is disabled') },


### PR DESCRIPTION
See my comment in my original PR https://github.com/r-spatial/leafem/pull/31#issuecomment-699107820. This PR addresses #29 

In this PR, I added a cache for expression. On first encounter, the expression is compiled into a JavaScript function using math.js's `compile`, and on subsequent calls, the `evalMath` function will used the compiled function rather than recompile every time. In theory this should be even faster than using the built in `eval` or `Function`. In practice it's probably the same.

Check it out and let me know what you think!