### PR TITLE
docs: correct Crancheck badge

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/r-spatial/leafem/workflows/R-CMD-check/badge.svg)](https://github.com/r-spatial/leafem/actions)
-[![cran checks](https://badges.cranchecks.info/worst/dplyr.svg)](https://cran.r-project.org/web/checks/check_results_leafem.html)
+[![cran checks](https://badges.cranchecks.info/worst/leafem.svg)](https://cran.r-project.org/web/checks/check_results_leafem.html)
 ![monthly](http://cranlogs.r-pkg.org/badges/leafem)
 ![total](http://cranlogs.r-pkg.org/badges/grand-total/leafem)
 [![CRAN](http://www.r-pkg.org/badges/version/leafem?color=009999)](https://cran.r-project.org/package=leafem)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![R-CMD-check](https://github.com/r-spatial/leafem/workflows/R-CMD-check/badge.svg)](https://github.com/r-spatial/leafem/actions)
 [![cran
-checks](https://badges.cranchecks.info/worst/dplyr.svg)](https://cran.r-project.org/web/checks/check_results_leafem.html)
+checks](https://badges.cranchecks.info/worst/leafem.svg)](https://cran.r-project.org/web/checks/check_results_leafem.html)
 ![monthly](http://cranlogs.r-pkg.org/badges/leafem)
 ![total](http://cranlogs.r-pkg.org/badges/grand-total/leafem)
 [![CRAN](http://www.r-pkg.org/badges/version/leafem?color=009999)](https://cran.r-project.org/package=leafem)


### PR DESCRIPTION
This fixes #62 and also uses the correct badge, as until now we used the `dplyr` badge ;)
