### PR TITLE
Fgb highlight fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,4 +91,5 @@ Suggests:
     terra,
     tools
 Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/R/file.R
+++ b/R/file.R
@@ -152,15 +152,11 @@ addLocalFile = function(map,
 
   map$dependencies <- c(
     map$dependencies,
+    leafletFileDependencies(),
     fileDependency(
       fn = path_outfile,
       layerId = layerId
     )
-  )
-
-  map$dependencies <- c(
-    map$dependencies,
-    leafletFileDependencies()
   )
 
   leaflet::invokeMethod(
@@ -308,6 +304,25 @@ addTileFolder = function(map,
 #' @inheritParams leaflet::addPolylines
 #' @param ... currently not used.
 #'
+#' @details
+#'   Styling options in `addFgb` offer flexibility by allowing
+#'   users to either specify styles directly as function arguments or define them
+#'   as attributes in the data object:
+#'
+#'   - **Direct Styling:** You can pass style arguments (e.g., `color`, `weight`,
+#'     `opacity`) directly to the function. These will apply uniformly to all features
+#'     in the layer.
+#'   - **Attribute-based Styling:** Alternatively, you can include styling properties
+#'     (e.g., `color`, `fillColor`, `weight`) as columns in your data object before
+#'     writing it to an FGB file. Set the corresponding arguments in `addFgb` to
+#'     `NULL`, and the function will use these attributes for styling during map
+#'     rendering. For example:
+#'      ```R
+#'      data$color <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
+#'      sf::st_write(obj = data, dsn = "myfile.fgb", driver = "FlatGeobuf")
+#'      leafem::addFgb(file = "myfile.fgb", color = NULL)
+#'      ```
+#'
 #' @examples
 #'  if (interactive()) {
 #'    library(leaflet)
@@ -414,10 +429,6 @@ addFgb = function(map,
       map$dependencies
       , fgbDependencies()
       , chromaJsDependencies()
-    )
-
-    map$dependencies = c(
-      map$dependencies
       , fileAttachment(path_layer, group)
     )
 

--- a/R/file.R
+++ b/R/file.R
@@ -316,11 +316,19 @@ addTileFolder = function(map,
 #'     (e.g., `color`, `fillColor`, `weight`) as columns in your data object before
 #'     writing it to an FGB file. Set the corresponding arguments in `addFgb` to
 #'     `NULL`, and the function will use these attributes for styling during map
-#'     rendering. For example:
+#'     rendering.
+#'
+#'     For example:
 #'      ```R
+#'      ## using custom `color`
 #'      data$color <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
 #'      sf::st_write(obj = data, dsn = "myfile.fgb", driver = "FlatGeobuf")
 #'      leafem::addFgb(file = "myfile.fgb", color = NULL)
+#'
+#'      ## using custom `fillColor`
+#'      data$fillColor <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
+#'      sf::st_write(obj = data, dsn = "myfile.fgb", driver = "FlatGeobuf")
+#'      leafem::addFgb(file = "myfile.fgb", fill = TRUE, fillColor = NULL)
 #'      ```
 #'
 #' @examples

--- a/inst/htmlwidgets/lib/FlatGeoBuf/fgb.js
+++ b/inst/htmlwidgets/lib/FlatGeoBuf/fgb.js
@@ -146,11 +146,9 @@ LeafletWidget.methods.addFlatGeoBuf = function (layerId,
                 },
                 // remove highlight when hover stops
                 'mouseout': function(e) {
-                    const layer = e.target;
-                    if (e.layer.feature.properties.color) {
-                      style.color = e.layer.feature.properties.color
-                    }
-                    layer.setStyle(style);
+                    const layer = e.layer;
+                    let oldstyle = updateStyleFromProperties(structuredClone(style), layer.feature.properties);
+                    layer.setStyle(oldstyle);
                     if (highlightOptions.sendToBack) {
                       layer.bringToBack();
                     }
@@ -221,7 +219,6 @@ function makePopup(popup, className) {
   return pop;
 }
 
-
 function json2table(json, cls) {
   let cols = Object.keys(json);
   let vals = Object.values(json);
@@ -286,6 +283,18 @@ function updateStyle(style_obj, feature, scale, scaleValues) {
 
   return out;
 }
+function updateStyleFromProperties(style, props) {
+  const keysToUpdate = ['stroke', 'color', 'weight', 'opacity',
+                        'fill', 'fillColor', 'fillOpacity', 'dashArray'];
+  // Create a shallow copy of style to avoid mutating the original object
+  const updatedStyle = { ...style };
+  keysToUpdate.forEach(key => {
+    if (updatedStyle[key] === null && props[key]) {
+      updatedStyle[key] = props[key];
+    }
+  });
+  return updatedStyle
+}
 
 
 function rescale(value, to_min, to_max, from_min, from_max) {
@@ -294,6 +303,7 @@ function rescale(value, to_min, to_max, from_min, from_max) {
   }
   return (value - from_min) / (from_max - from_min) * (to_max - to_min) + to_min;
 }
+
 
 
 

--- a/leafem.Rproj
+++ b/leafem.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: a2cce78f-b118-47fb-83fb-d62c6c6506d5
 
 RestoreWorkspace: Default
 SaveWorkspace: Default
@@ -16,6 +15,8 @@ LaTeX: pdfLaTeX
 StripTrailingWhitespace: Yes
 
 BuildType: Package
+PackageUseDevtools: Yes
+PackageCleanBeforeInstall: No
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageBuildArgs: --no-manual
 PackageCheckArgs: --as-cran --no-manual

--- a/man/addCOG.Rd
+++ b/man/addCOG.Rd
@@ -67,8 +67,8 @@ Add Cloud Optimised Geotiff (COG) to a leaflet map.
 }
 \details{
 This function will overlay Cloud Optimised Geotiff data from a remote url on
-a leaflet map. Like `addGeotiff` it uses the leaflet plugin
-'georaster-layer-for-leaflet' to render the data. See `addGeotiff` for a bit
+a leaflet map. Like \code{addGeotiff} it uses the leaflet plugin
+'georaster-layer-for-leaflet' to render the data. See \code{addGeotiff} for a bit
 more detail what that means.
 }
 \examples{

--- a/man/addFgb.Rd
+++ b/man/addFgb.Rd
@@ -116,11 +116,19 @@ in the layer.
 (e.g., \code{color}, \code{fillColor}, \code{weight}) as columns in your data object before
 writing it to an FGB file. Set the corresponding arguments in \code{addFgb} to
 \code{NULL}, and the function will use these attributes for styling during map
-rendering. For example:
+rendering.
 
-\if{html}{\out{<div class="sourceCode R">}}\preformatted{data$color <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
+For example:
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{## using custom `color`
+data$color <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
 sf::st_write(obj = data, dsn = "myfile.fgb", driver = "FlatGeobuf")
 leafem::addFgb(file = "myfile.fgb", color = NULL)
+
+## using custom `fillColor`
+data$fillColor <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
+sf::st_write(obj = data, dsn = "myfile.fgb", driver = "FlatGeobuf")
+leafem::addFgb(file = "myfile.fgb", fill = TRUE, fillColor = NULL)
 }\if{html}{\out{</div>}}
 }
 }

--- a/man/addFgb.Rd
+++ b/man/addFgb.Rd
@@ -91,18 +91,38 @@ options for each label. Default \code{NULL}}
 }
 \description{
 flatgeobuf is a performant binary geo-spatial file format suitable for
-  serving large data. For more details see
-  \url{https://github.com/flatgeobuf/flatgeobuf} and the respective
-  documentation for the GDAL/OGR driver at
-  \url{https://gdal.org/en/latest/drivers/vector/flatgeobuf.html}. \cr
-  \cr
-  In contrast to classical ways of serving data from R onto a leaflet map,
-  flatgeobuf can stream the data chunk by chunk so that rendering of the map
-  is more or less instantaneous. The map is responsive while data is still
-  loading so that popup queries, zooming and panning will work even
-  though not all data has been rendered yet. This makes for a rather pleasant
-  user experience as we don't have to wait for all data to be added to the map
-  before interacting with it.
+serving large data. For more details see
+\url{https://github.com/flatgeobuf/flatgeobuf} and the respective
+documentation for the GDAL/OGR driver at
+\url{https://gdal.org/en/latest/drivers/vector/flatgeobuf.html}. \cr
+\cr
+In contrast to classical ways of serving data from R onto a leaflet map,
+flatgeobuf can stream the data chunk by chunk so that rendering of the map
+is more or less instantaneous. The map is responsive while data is still
+loading so that popup queries, zooming and panning will work even
+though not all data has been rendered yet. This makes for a rather pleasant
+user experience as we don't have to wait for all data to be added to the map
+before interacting with it.
+}
+\details{
+Styling options in \code{addFgb} offer flexibility by allowing
+users to either specify styles directly as function arguments or define them
+as attributes in the data object:
+\itemize{
+\item \strong{Direct Styling:} You can pass style arguments (e.g., \code{color}, \code{weight},
+\code{opacity}) directly to the function. These will apply uniformly to all features
+in the layer.
+\item \strong{Attribute-based Styling:} Alternatively, you can include styling properties
+(e.g., \code{color}, \code{fillColor}, \code{weight}) as columns in your data object before
+writing it to an FGB file. Set the corresponding arguments in \code{addFgb} to
+\code{NULL}, and the function will use these attributes for styling during map
+rendering. For example:
+
+\if{html}{\out{<div class="sourceCode R">}}\preformatted{data$color <- colorNumeric(palette = "viridis", domain = data$var)(data$var)
+sf::st_write(obj = data, dsn = "myfile.fgb", driver = "FlatGeobuf")
+leafem::addFgb(file = "myfile.fgb", color = NULL)
+}\if{html}{\out{</div>}}
+}
 }
 \examples{
  if (interactive()) {

--- a/man/addLogo.Rd
+++ b/man/addLogo.Rd
@@ -38,8 +38,8 @@ showLogo(map, layerId)
 
 \item{alpha}{opacity of the added image.}
 
-\item{src}{DEPRECATED. The function now automatically determines if `img` is
-a local or remote image using `file.exists(img)`.}
+\item{src}{DEPRECATED. The function now automatically determines if \code{img} is
+a local or remote image using \code{file.exists(img)}.}
 
 \item{url}{an optional URL to be opened when clicking on the image
 (e.g. company's homepage).}

--- a/man/addMouseCoordinates.Rd
+++ b/man/addMouseCoordinates.Rd
@@ -47,13 +47,13 @@ on the map.
 \details{
 If style is set to "detailed", the following information will be displayed:
 \itemize{
-  \item x: x-position of the mouse cursor in projected coordinates
-  \item y: y-position of the mouse cursor in projected coordinates
-  \item epsg: the epsg code of the coordinate reference system of the map
-  \item proj4: the proj4 definition of the coordinate reference system of the map
-  \item lat: latitude position of the mouse cursor
-  \item lon: longitude position of the mouse cursor
-  \item zoom: the current zoom level
+\item x: x-position of the mouse cursor in projected coordinates
+\item y: y-position of the mouse cursor in projected coordinates
+\item epsg: the epsg code of the coordinate reference system of the map
+\item proj4: the proj4 definition of the coordinate reference system of the map
+\item lat: latitude position of the mouse cursor
+\item lon: longitude position of the mouse cursor
+\item zoom: the current zoom level
 }
 
 By default, only 'lat', 'lon' and 'zoom' are shown. To show the details about

--- a/man/addPMPolygons.Rd
+++ b/man/addPMPolygons.Rd
@@ -48,7 +48,7 @@ addPMPolylines(
 \item{group}{group name.}
 
 \item{pane}{the map pane to which the layer should be added. See
-[leaflet](addMapPane) for details.}
+\href{addMapPane}{leaflet} for details.}
 
 \item{attribution}{optional attribution character string.}
 }
@@ -61,12 +61,12 @@ Add polylines stored as PMTiles
 }
 \details{
 These functions can be used to add cloud optimized vector tiles data in
-  the `.pmtiles` format stored in an Amazon Web Services (AWS) S3 bucket to a
-  leaflet map. For instructions on how to create these files, see
-  \url{https://github.com/protomaps/PMTiles}.
+the \code{.pmtiles} format stored in an Amazon Web Services (AWS) S3 bucket to a
+leaflet map. For instructions on how to create these files, see
+\url{https://github.com/protomaps/PMTiles}.
 
-  NOTE: You may not see the tiles rendered in the RStudio viewer pane. Make
-  sure to open the map in a browser.
+NOTE: You may not see the tiles rendered in the RStudio viewer pane. Make
+sure to open the map in a browser.
 }
 \section{Functions}{
 \itemize{

--- a/man/addRasterRGB.Rd
+++ b/man/addRasterRGB.Rd
@@ -34,7 +34,7 @@ addStarsRGB(
 \arguments{
 \item{map}{a map widget object created from `leaflet()``}
 
-\item{x}{a  `RasterBrick`, `RasterStack` or `stars`` raster object}
+\item{x}{a  \code{RasterBrick}, \code{RasterStack} or `stars`` raster object}
 
 \item{r}{integer. Index of the Red channel/band, between 1 and nlayers(x)}
 
@@ -43,11 +43,11 @@ addStarsRGB(
 \item{b}{integer. Index of the Blue channel/band, between 1 and nlayers(x)}
 
 \item{quantiles}{the upper and lower quantiles used for color stretching.
-If set to NULL, stretching is performed basing on `domain` argument.}
+If set to NULL, stretching is performed basing on \code{domain} argument.}
 
 \item{domain}{the upper and lower values used for color stretching.
-This is used only if `quantiles` is NULL.
-If both `domain` and `quantiles` are set to NULL, stretching is applied
+This is used only if \code{quantiles} is NULL.
+If both \code{domain} and \code{quantiles} are set to NULL, stretching is applied
 based on min-max values.}
 
 \item{na.color}{the color to be used for NA pixels}

--- a/man/addReactiveFeatures.Rd
+++ b/man/addReactiveFeatures.Rd
@@ -50,14 +50,14 @@ See \code{\link[leaflet]{addControl}} for details.}
 }
 \description{
 This function adds a layer to a map that is dependent on another layer.
-  The reactive layer will be shown/hidden when holding the Ctrl-button on your
-  keyboard and performing the action defined by \code{on}. \code{on} can be
-  either "click" (default) or "mouseover".
+The reactive layer will be shown/hidden when holding the Ctrl-button on your
+keyboard and performing the action defined by \code{on}. \code{on} can be
+either "click" (default) or "mouseover".
 
-  Note: \code{srcLayer} needs to be added to the map using \code{\link[leaflet]{addGeoJSON}}
-  because we need to be able to link the two layers by a common attribute
-  defined by argument \code{by}. Linking will be done via \code{group} name
-  of \code{srcLayer}.
+Note: \code{srcLayer} needs to be added to the map using \code{\link[leaflet]{addGeoJSON}}
+because we need to be able to link the two layers by a common attribute
+defined by argument \code{by}. Linking will be done via \code{group} name
+of \code{srcLayer}.
 }
 \examples{
 library(leaflet)

--- a/man/addTileFolder.Rd
+++ b/man/addTileFolder.Rd
@@ -39,5 +39,5 @@ but can be overridden.}
 }
 \description{
 Add tiled raster data pyramids from a local folder that was created with
-  gdal2tiles.py (see \url{https://gdal.org/en/latest/programs/gdal2tiles.html} for details).
+gdal2tiles.py (see \url{https://gdal.org/en/latest/programs/gdal2tiles.html} for details).
 }

--- a/man/extendLayersControl.Rd
+++ b/man/extendLayersControl.Rd
@@ -15,55 +15,57 @@ extendLayersControl(
 )
 }
 \arguments{
-\item{map}{A `leaflet` or `mapview` object to which the extended layers control will be added.}
+\item{map}{A \code{leaflet} or \code{mapview} object to which the extended layers control will be added.}
 
 \item{view_settings}{A list specifying the view settings for each layer. Each list element should contain
 either:
 \itemize{
-  \item \code{coords}: A vector of length 2 (latitude, longitude) for setting the view, or length 4
-  (bounding box: lat1, lng1, lat2, lng2) for fitting the bounds.
-  \item \code{zoom}: The zoom level (used for `setView`).
-  \item \code{fly} (optional): A logical indicating whether to use `flyTo` or `flyToBounds` instead of `setView` or `fitBounds`.
-  \item \code{options} (optional): Additional options to pass to `setView`, `fitBounds`, or `flyTo`.
+\item \code{coords}: A vector of length 2 (latitude, longitude) for setting the view, or length 4
+(bounding box: lat1, lng1, lat2, lng2) for fitting the bounds.
+\item \code{zoom}: The zoom level (used for \code{setView}).
+\item \code{fly} (optional): A logical indicating whether to use \code{flyTo} or \code{flyToBounds} instead of \code{setView} or \code{fitBounds}.
+\item \code{options} (optional): Additional options to pass to \code{setView}, \code{fitBounds}, or \code{flyTo}.
 }}
 
-\item{home_btns}{Logical. If `TRUE`, adds a "home" button next to each layer name in the layer control.
+\item{home_btns}{Logical. If \code{TRUE}, adds a "home" button next to each layer name in the layer control.
 Clicking the home button zooms the map to the view specified for that layer in \code{view_settings}.}
 
 \item{home_btn_options}{A list of options to customize the home button appearance and behavior.
 Possible options include:
-- `text`: The text or emoji to display on the button (default is '🏠').
-- `cursor`: CSS cursor style for the button (default is 'pointer').
-- `class`: CSS class name for the button (default is 'leaflet-home-btn').
-- `styles`: Semicolon separated CSS-string (default is 'float: inline-end;').}
+\itemize{
+\item \code{text}: The text or emoji to display on the button (default is '🏠').
+\item \code{cursor}: CSS cursor style for the button (default is 'pointer').
+\item \code{class}: CSS class name for the button (default is 'leaflet-home-btn').
+\item \code{styles}: Semicolon separated CSS-string (default is 'float: inline-end;').
+}}
 
-\item{setviewonselect}{Logical. If `TRUE` (default) sets the view when the layer is selected.}
+\item{setviewonselect}{Logical. If \code{TRUE} (default) sets the view when the layer is selected.}
 
 \item{opacityControl}{A list specifying the opacity control settings for each layer. Each list element should contain:
 \itemize{
-  \item \code{min}: Minimum opacity value (default is 0).
-  \item \code{max}: Maximum opacity value (default is 1).
-  \item \code{step}: Step size for the opacity slider (default is 0.1).
-  \item \code{default}: Default opacity value (default is 1).
-  \item \code{width}: Width of the opacity slider (default is '100%').
-  \item \code{class}: CSS class name for the slider (default is 'leaflet-opacity-slider').
+\item \code{min}: Minimum opacity value (default is 0).
+\item \code{max}: Maximum opacity value (default is 1).
+\item \code{step}: Step size for the opacity slider (default is 0.1).
+\item \code{default}: Default opacity value (default is 1).
+\item \code{width}: Width of the opacity slider (default is '100\%').
+\item \code{class}: CSS class name for the slider (default is 'leaflet-opacity-slider').
 }}
 
-\item{includelegends}{Logical. If `TRUE` (default), appends legends to the layer control. Legends are matched
+\item{includelegends}{Logical. If \code{TRUE} (default), appends legends to the layer control. Legends are matched
 to layers by their group name. The legends need to be added with corresponding layer IDs.}
 }
 \value{
-A modified `leaflet` map object with extended layers control including view controls, home buttons, opacity controls, and legends.
+A modified \code{leaflet} map object with extended layers control including view controls, home buttons, opacity controls, and legends.
 }
 \description{
-This function extends an existing layers control in a `leaflet` map by adding custom views, home buttons,
-opacity controls, and legends. It enhances the functionality of a layers control created with `leaflet`
-or `leaflet.extras`.
+This function extends an existing layers control in a \code{leaflet} map by adding custom views, home buttons,
+opacity controls, and legends. It enhances the functionality of a layers control created with \code{leaflet}
+or \code{leaflet.extras}.
 }
 \details{
-This function generates JavaScript that listens for `overlayadd` or `baselayerchange` events
+This function generates JavaScript that listens for \code{overlayadd} or \code{baselayerchange} events
 and automatically sets the view or zoom level according to the specified \code{view_settings}.
-If `home_btns` is enabled, a home button is added next to each layer in the layer control.
+If \code{home_btns} is enabled, a home button is added next to each layer in the layer control.
 When clicked, it zooms the map to the predefined view of that layer.
 The opacity control slider allows users to adjust the opacity of layers. The legend will be appended
 to the corresponding layer control, matched by the layer's group name.

--- a/man/imagequeryOptions.Rd
+++ b/man/imagequeryOptions.Rd
@@ -25,9 +25,9 @@ to 'mousemove'.}
 
 \item{prefix}{a character string to be shown as prefix for the layerId.}
 
-\item{noData}{the text shown when the mouse is over a `NoData Value` as
-defined by GDAL. The default "NoData Value" will use whatever is defined in the
-Geotif.}
+\item{noData}{the text shown when the mouse is over a \verb{NoData Value} as
+identified by GDAL. The default "NoData Value" will show whatever is defined by
+the Geotiff metadata.}
 }
 \description{
 Imagequery options for addGeoRaster, addGeotiff and addCOG

--- a/man/paintRules.Rd
+++ b/man/paintRules.Rd
@@ -33,9 +33,9 @@ paintRules(
 
 \item{opacity}{point opacity}
 
-\item{dash}{either `NULL` (default) for a solid line or a numeric vector
+\item{dash}{either \code{NULL} (default) for a solid line or a numeric vector
 of length 2 denoting segment length and spce between segments (in pixels),
-e.g. `c(5, 3)`}
+e.g. \code{c(5, 3)}}
 }
 \description{
 Styling options for PMTiles


### PR DESCRIPTION
- This PR fixes issues with highlighting behavior (**mouseout**) in addFgb by **correctly restoring the original style** using a deep copy of the `style` object (with `structuredClone` and `{ ...style }`). Previously, only the `color` property was partially supported, and its behavior was incorrect. See https://github.com/r-spatial/leafem/pull/85 for an example app.

- Introduced the function `updateStyleFromProperties` to update the highlighted style, if the relevant function argument is NULL and the data has a property with this name (e.g.: `color`, `weight`, etc..).

- Added some explanation to the **@details** section, outlining how to use direct styling arguments and feature-based styling from data properties. Addresses #87


I also simplified some `map$dependencies` calls and added `Roxygen: list(markdown = TRUE)` do the Description. This helps with rendering the docs correctly.